### PR TITLE
feat: add PR template and DPGA DPI collection link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## What does this PR do?
+
+<!-- One sentence summary of the change -->
+
+## Type of change
+
+- [ ] Add resource
+- [ ] Fix broken link
+- [ ] Update existing entry
+- [ ] Documentation / structure improvement
+- [ ] Bug fix / CI fix
+
+## Checklist (for resource additions)
+
+- [ ] Resource is freely accessible (not paywalled)
+- [ ] Resource is actively maintained or recently published
+- [ ] Resource is directly relevant to DPI or DPG
+- [ ] Added to the correct section in alphabetical order
+- [ ] Description is one sentence, starts with capital, ends with period
+- [ ] No duplicate — checked that it is not already listed
+- [ ] Ran `lychee` locally or verified URL resolves correctly
+
+## Related issue
+
+Closes #<!-- issue number -->

--- a/README.MD
+++ b/README.MD
@@ -57,6 +57,7 @@ The main reference points for anyone working on DPI or evaluating DPGs.
 ### 🏗️ DPI Core Frameworks
 
 - [UNDP Digital Public Goods Standard](https://digitalpublicgoods.net/standard/) — nine criteria a solution must meet to be certified as a DPG
+- [DPGA DPGs for DPI Collection](https://www.digitalpublicgoods.net/collections/coll-dpi) — curated set of certified DPGs mapped to the four DPI use cases: identity, payments, data exchange, and government transfers
 - [GovStack Reference Architecture](https://specs.govstack.global/) — a building-block model for assembling government digital services
 - [ITU Digital Transformation Framework](https://www.itu.int/en/ITU-D/Pages/default.aspx) — guidelines and metrics from the ITU for national digital transformation
 - [OECD Digital Government Policy Framework](https://www.oecd.org/governance/digital-government/oecd-digital-government-policy-framework.htm) — six dimensions for assessing how mature a country's digital government is


### PR DESCRIPTION
## What does this PR do?

Adds the PR template and the official DPGA 'DPGs for DPI' collection link.

## Type of change

- [x] Add resource
- [x] Documentation / structure improvement

## Checklist (for resource additions)

- [x] Resource is freely accessible (not paywalled)
- [x] Resource is actively maintained or recently published
- [x] Resource is directly relevant to DPI or DPG
- [x] Added to the correct section in alphabetical order
- [x] Description is one sentence, starts with capital, ends with period
- [x] No duplicate — checked that it is not already listed
- [x] Ran `lychee` locally or verified URL resolves correctly

## Related issue

Closes #5