### PR TITLE
feat: add Digital Youth Work research report (2026)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -275,6 +275,10 @@ Want to contribute a country profile? See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [AfDB Digital Transformation Strategy](https://www.afdb.org/en/topics-and-sectors/topics/digital-transformation) — Africa's digital infrastructure priorities
 - [G20 DPI Framework](https://www.g20.org/) — G20 DPI commitments and principles
 
+### 👩‍💻 Digital Workforce & Inclusion
+
+- [Where is Digital Youth Work? Policy Invisibility and the Case for Recognition](https://dywrhubreport2026.netlify.app/) — University of Leeds / INCLUDE+ Network (2026); reviews 800+ government bodies and 26 policies to show how youth workers — the most effective digital inclusion practitioners — are systematically excluded from policy and funding
+
 ---
 
 ## 🎓 Courses & Learning


### PR DESCRIPTION
## What does this PR do?

Adds a new subsection **Digital Workforce & Inclusion** under Research & Reports, with the first entry being the Digital Youth Work Research Hub report (2026).

## Type of change

- [x] Add resource

## Checklist

- [x] Resource is freely accessible (not paywalled)
- [x] Resource is actively maintained or recently published
- [x] Resource is directly relevant to DPI or DPG
- [x] Added to the correct section
- [x] Description is one sentence, starts with capital, ends with period
- [x] No duplicate — checked that it is not already listed
- [x] URL resolves correctly

## About this resource

**Title:** Where is Digital Youth Work? Policy Invisibility and the Case for Recognition
**Authors:** Dr Alicja Pawluczuk & Cristina Bacalso
**Publisher:** Digital Youth Work Research Hub, University of Leeds / INCLUDE+ Network
**Year:** 2026
**URL:** https://dywrhubreport2026.netlify.app/

Reviewed 800+ government bodies and 26 policies. Key finding: young people are consistently named as a digital inclusion priority, but youth workers — the most effective last-mile practitioners — are almost never mentioned in policy or funding.