### PR TITLE
feat: replace Jobs & Funding card with DPGA DPI Collection

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -933,11 +933,11 @@
         <p>Free MOOCs, certifications, and learning paths for DPI/DPG practitioners.</p>
         <span class="tag">8 courses</span>
       </a>
-      <a class="card" href="https://github.com/paulo-amaral/awesome-digital-public-infrastructure#-jobs--opportunities">
-        <div class="card-icon"><i class="fa-solid fa-briefcase"></i></div>
-        <h3>Jobs & Funding</h3>
-        <p>Job boards, fellowships, and grants at the intersection of tech and development.</p>
-        <span class="tag">10+ links</span>
+      <a class="card" href="https://www.digitalpublicgoods.net/collections/coll-dpi" target="_blank" rel="noopener">
+        <div class="card-icon"><i class="fa-solid fa-certificate"></i></div>
+        <h3>DPGA DPI Collection</h3>
+        <p>Certified digital public goods mapped to DPI use cases — identity, payments, data exchange, and government transfers.</p>
+        <span class="tag">11 certified DPGs</span>
       </a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Removed Jobs & Funding card from the webpage (section already removed from README)
- Added DPGA DPI Collection card linking to `digitalpublicgoods.net/collections/coll-dpi`
- Card highlights 11 certified DPGs across the 4 core DPI use cases

## Type of change
- [x] Content update / curation

## Quality checklist
- [x] Link tested and accessible
- [x] Consistent with README changes already merged