### PR TITLE
fix: replace all co-develop.net links with active domains

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -41,7 +41,7 @@ https://e-resident.gov.ee/*
 https://conectesus.saude.gov.br/*
 
 # Intermittently unreachable or suspended government sites
-https://www.co-develop.net/*
+# co-develop.net domain migrated to codevelop.fund — old domain removed from repo
 https://www.mssi.gov.tl/*
 https://www.moh.gov.tl/*
 https://www.rdtl.tl/*

--- a/README.MD
+++ b/README.MD
@@ -61,9 +61,9 @@ The main reference points for anyone working on DPI or evaluating DPGs.
 - [ITU Digital Transformation Framework](https://www.itu.int/en/ITU-D/Pages/default.aspx) — guidelines and metrics from the ITU for national digital transformation
 - [OECD Digital Government Policy Framework](https://www.oecd.org/governance/digital-government/oecd-digital-government-policy-framework.htm) — six dimensions for assessing how mature a country's digital government is
 - [World Bank DPI Framework](https://www.worldbank.org/en/topic/digitaldevelopment) — policy and investment guidance for national digital infrastructure
-- [Co-Develop DPI Framework](https://www.co-develop.net/) — practical guidance for countries designing their own DPI
+- [Co-Develop DPI Framework](https://www.codevelop.fund/) — practical guidance for countries designing their own DPI
 - [Principles for Digital Development](https://digitalprinciples.org/) — nine principles adopted by 300+ organizations working in tech and development
-- [DPI Safeguards Framework](https://www.co-develop.net/dpi-safeguards) — rights-based guidance for DPI design
+- [DPI Safeguards Framework](https://www.dpi-safeguards.org/) — rights-based guidance for DPI design
 - [IDEA International — DPI & Democracy](https://www.idea.int/theme/digital-public-infrastructure) — how DPI shapes electoral integrity, civic participation, and democratic governance
 
 ### 🤖 AI & Emerging Technology
@@ -239,7 +239,7 @@ Want to contribute a country profile? See [CONTRIBUTING.md](CONTRIBUTING.md).
 |---|---|
 | [Digital Impact Alliance (DIAL)](https://digitalimpactalliance.org/) | Research on digital development |
 | [Digital Square](https://digitalsquare.org/) | Grants for global digital health tools |
-| [Co-Develop Fund](https://www.co-develop.net/) | Philanthropic funding for DPI in low-income countries |
+| [Co-Develop Fund](https://www.codevelop.fund/) | Philanthropic funding for DPI in low-income countries |
 | [Gates Foundation](https://www.gatesfoundation.org/our-work/programs/global-growth-and-opportunity/inclusive-financial-systems) | Financial inclusion |
 | [Omidyar Network](https://omidyar.com/) | Investment in DPI and open internet |
 | [Rockefeller Foundation](https://www.rockefellerfoundation.org/) | Digital equity |

--- a/docs/index.html
+++ b/docs/index.html
@@ -781,7 +781,7 @@
         <div class="link-title">Principles for Digital Development</div>
         <div class="link-desc">Nine principles adopted by 300+ organizations for technology in development.</div>
       </a>
-      <a class="link-item" href="https://www.co-develop.net/dpi-safeguards" target="_blank" rel="noopener">
+      <a class="link-item" href="https://www.dpi-safeguards.org/" target="_blank" rel="noopener">
         <div class="link-meta">
           <span class="link-org">Co-Develop</span>
           <span class="link-tag">Safeguards</span>
@@ -850,7 +850,7 @@
         </div>
         <i class="fa-solid fa-arrow-up-right-from-square paper-icon"></i>
       </a>
-      <a class="paper-item" href="https://www.co-develop.net/dpi-moonshot" target="_blank" rel="noopener">
+      <a class="paper-item" href="https://dial.global/research/economics-of-digital-public-infrastructure/" target="_blank" rel="noopener">
         <div class="paper-left">
           <span class="paper-org">Co-Develop</span>
           <span class="paper-year">2022</span>


### PR DESCRIPTION
## Summary
`co-develop.net` domain is suspended. Updated all 5 references across README, index.html, and .lycheeignore:

| Old URL | New URL |
|---------|---------|
| `co-develop.net/` (×2) | `codevelop.fund/` |
| `co-develop.net/dpi-safeguards` (×2) | `dpi-safeguards.org/` |
| `co-develop.net/dpi-moonshot` (index.html) | `dial.global/research/economics-of-digital-public-infrastructure/` |

Both `codevelop.fund` and `dpi-safeguards.org` return HTTP 200. Removed `co-develop.net/*` from .lycheeignore.

## Type of change
- [x] Bug fix (broken link)