### PR TITLE
feat: add Co-Develop publications link to Organizations section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -239,7 +239,7 @@ Want to contribute a country profile? See [CONTRIBUTING.md](CONTRIBUTING.md).
 |---|---|
 | [Digital Impact Alliance (DIAL)](https://digitalimpactalliance.org/) | Research on digital development |
 | [Digital Square](https://digitalsquare.org/) | Grants for global digital health tools |
-| [Co-Develop Fund](https://www.codevelop.fund/) | Philanthropic funding for DPI in low-income countries |
+| [Co-Develop Fund](https://www.codevelop.fund/) | Philanthropic funding for DPI in low-income countries — [publications](https://www.codevelop.fund/publications): evidence compendium, sector reports (health, agriculture, SIDS), and deployment guidance |
 | [Gates Foundation](https://www.gatesfoundation.org/our-work/programs/global-growth-and-opportunity/inclusive-financial-systems) | Financial inclusion |
 | [Omidyar Network](https://omidyar.com/) | Investment in DPI and open internet |
 | [Rockefeller Foundation](https://www.rockefellerfoundation.org/) | Digital equity |


### PR DESCRIPTION
Added inline link to codevelop.fund/publications alongside the Co-Develop Fund entry — evidence compendium, sector reports (health, agriculture, SIDS), and DPI deployment guidance.

## What does this PR do?

<!-- One sentence summary of the change -->

## Type of change

- [x] Add resource
- [ ] Fix broken link
- [ ] Update existing entry
- [ ] Documentation / structure improvement
- [ ] Bug fix / CI fix

## Checklist (for resource additions)

- [ ] Resource is freely accessible (not paywalled)
- [ ] Resource is actively maintained or recently published
- [x] Resource is directly relevant to DPI or DPG
- [ ] Added to the correct section in alphabetical order
- [ ] Description is one sentence, starts with capital, ends with period
- [ ] No duplicate — checked that it is not already listed
- [ ] Ran `lychee` locally or verified URL resolves correctly

## Related issue

Closes #<!-- issue number -->
