### PR TITLE
feat: add BMZ Digital.Global

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -239,6 +239,7 @@ Want to contribute a country profile? See [CONTRIBUTING.md](CONTRIBUTING.md).
 |---|---|
 | [Digital Impact Alliance (DIAL)](https://digitalimpactalliance.org/) | Research on digital development |
 | [Digital Square](https://digitalsquare.org/) | Grants for global digital health tools |
+| [BMZ Digital.Global](https://www.bmz-digital.global/en/) | German Federal Ministry (BMZ) digital development programme — umbrella for GovStack, FAIR Forward (AI for development), atingi (digital skills), and Digital Transformation Centers |
 | [Co-Develop Fund](https://www.codevelop.fund/) | Philanthropic funding for DPI in low-income countries — [publications](https://www.codevelop.fund/publications): evidence compendium, sector reports (health, agriculture, SIDS), and deployment guidance |
 | [Gates Foundation](https://www.gatesfoundation.org/our-work/programs/global-growth-and-opportunity/inclusive-financial-systems) | Financial inclusion |
 | [Omidyar Network](https://omidyar.com/) | Investment in DPI and open internet |

--- a/docs/index.html
+++ b/docs/index.html
@@ -829,6 +829,14 @@
         <div class="link-title">DPI & Democracy</div>
         <div class="link-desc">How Digital Public Infrastructure shapes electoral integrity, civic participation, and democratic governance worldwide.</div>
       </a>
+      <a class="link-item" href="https://www.bmz-digital.global/en/" target="_blank" rel="noopener">
+        <div class="link-meta">
+          <span class="link-org">BMZ / Germany</span>
+          <span class="link-tag">Programme</span>
+        </div>
+        <div class="link-title">BMZ Digital.Global</div>
+        <div class="link-desc">German Federal Ministry digital development programme — umbrella for GovStack, FAIR Forward (AI), atingi (digital skills), and Digital Transformation Centers worldwide.</div>
+      </a>
     </div>
     <a class="see-more" href="https://github.com/paulo-amaral/awesome-digital-public-infrastructure#-frameworks--standards">
       All frameworks on GitHub <i class="fa-solid fa-arrow-right"></i>


### PR DESCRIPTION
## Summary
Added [BMZ Digital.Global](https://www.bmz-digital.global/en/) — the German Federal Ministry (BMZ) digital development programme — to:
- **README** → Organizations → Foundations & Alliances table
- **index.html** → frameworks link-items section

BMZ Digital.Global is the umbrella for GovStack, FAIR Forward (AI for development), atingi (digital skills), and Digital Transformation Centers.

## Type of change
- [x] New resource added