### PR TITLE
feat: add UNICEF Learning Passport (closes #19)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -140,6 +140,7 @@ Software certified by the [Digital Public Goods Alliance](https://digitalpublicg
 | [Kolibri](https://learningequality.org/kolibri/) | Works offline, designed for schools with no reliable internet | — | MIT |
 | [OpenEDX](https://openedx.org/) | Powers edX and over 100 national deployments | — | AGPL 3.0 |
 | [Sunbird](https://sunbird.org/) | India's DIKSHA learning platform, open-sourced | 250M+ | MIT |
+| [Learning Passport](https://www.learningpassport.org/) | UNICEF online/offline/mobile learning platform for children in crisis and low-connectivity contexts | 10M+ | — |
 
 ### 🌿 Climate & Environment
 


### PR DESCRIPTION
## Summary
Adds [Learning Passport](https://www.learningpassport.org/) to the **Education** DPG table.

- UNICEF online/mobile/offline learning platform
- 10M+ registered users across 47 countries
- Designed for children in crisis and low-connectivity contexts
- Requested via issue #19 (submitted by @bidi925)

> Note: categorized under Education DPGs rather than Frameworks & Standards as suggested in the issue — better fit given it's a platform/solution, not a policy framework.

Closes #19

## Type of change
- [x] New resource added