### PR TITLE
feat: add Lessons Learned contribution template and issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-resource.yml
+++ b/.github/ISSUE_TEMPLATE/add-resource.yml
@@ -43,7 +43,7 @@ body:
         - Organizations & Communities
         - Research & Reports
         - Courses & Learning
-        - Jobs & Opportunities
+        - Field Notes
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/share-lesson-learned.yml
+++ b/.github/ISSUE_TEMPLATE/share-lesson-learned.yml
@@ -1,0 +1,66 @@
+name: Share a Lesson Learned
+description: Contribute a hard-won lesson from a real DPI or DPG implementation
+title: "[Field Note] "
+labels: ["field-note", "needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your field experience! These lessons are the most valuable content in this list — things that don't appear in any framework document.
+        Please describe one clear, actionable insight from a real implementation.
+
+  - type: input
+    id: context
+    attributes:
+      label: Context
+      description: Where did this happen? Country, organisation, project, or sector.
+      placeholder: "e.g. UNICEF Timor-Leste, Ministry of Health data system, 2024"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      description: Which field-note category does this lesson best fit?
+      options:
+        - Design & Architecture
+        - Offline-First & Last Mile
+        - Digital Divide, AI Divide & Inclusion
+        - Emerging Technologies
+        - Policies, Standards & Laws
+        - Common Mistakes
+        - Timor-Leste & the Pacific
+        - Other (describe in the lesson)
+    validations:
+      required: true
+
+  - type: textarea
+    id: lesson
+    attributes:
+      label: The lesson
+      description: One clear, actionable insight. Start with a bold title, then explain the "why" in 2–4 sentences. Real examples beat abstract principles.
+      placeholder: |
+        **Your title here** — Explain what you learned and why it matters.
+        What went wrong (or right)? What would you tell someone starting this project today?
+    validations:
+      required: true
+
+  - type: input
+    id: reference
+    attributes:
+      label: Reference or link (optional)
+      description: A report, article, or public document that supports or illustrates this lesson.
+      placeholder: "https://..."
+
+  - type: checkboxes
+    id: criteria
+    attributes:
+      label: Checklist
+      options:
+        - label: This is based on real implementation experience (not theoretical)
+          required: true
+        - label: The lesson is actionable — someone can apply it in their own project
+          required: true
+        - label: No confidential or personally identifiable information is included
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,21 @@ Country profiles live in `docs/country-profiles/`. Use the template in that dire
 4. Key lessons / field notes
 5. References
 
+### Field Notes (Lessons Learned)
+
+Field notes are hard-won insights from real DPI implementations — the kind of thing that doesn't appear in any framework document.
+
+**Two ways to contribute:**
+
+1. **Via issue (easiest):** [Open a Lesson Learned issue](https://github.com/paulo-amaral/awesome-digital-public-infrastructure/issues/new?template=share-lesson-learned.yml) — fill in the form and a maintainer will add it.
+2. **Via pull request:** Copy `docs/field-notes/TEMPLATE.md`, create a new file (e.g. `docs/field-notes/your-topic.md`), add a row to `docs/field-notes/README.md`, and open a PR.
+
+**What makes a good lesson:**
+- Based on real experience, not theory
+- One clear, actionable insight per bullet
+- Explains the *why* — what went wrong or right and what to do differently
+- No confidential or personally identifiable information
+
 ---
 
 ## Code of Conduct

--- a/docs/field-notes/README.md
+++ b/docs/field-notes/README.md
@@ -18,4 +18,7 @@ Things learned working in the field that don't appear in any framework document.
 
 ---
 
+**Want to contribute a lesson?**
+→ [Submit via issue](https://github.com/paulo-amaral/awesome-digital-public-infrastructure/issues/new?template=share-lesson-learned.yml) — or copy [TEMPLATE.md](TEMPLATE.md) and open a PR.
+
 ← [Back to main list](../../README.MD)

--- a/docs/field-notes/TEMPLATE.md
+++ b/docs/field-notes/TEMPLATE.md
@@ -1,0 +1,20 @@
+# 🏷️ Field Notes — [Your Topic Here]
+
+> One-line summary of what this note covers and who it is for.
+
+---
+
+- **Bold title for lesson 1** — Explain the insight in 2–4 sentences. What went wrong or right? What would you tell someone starting this project today? Real examples beat abstract principles.
+- **Bold title for lesson 2** — Keep each lesson self-contained. A reader should be able to act on it without reading the others.
+- **Bold title for lesson 3** — Aim for 3–6 lessons per page. Quality over quantity.
+
+---
+
+## How to contribute
+
+1. Copy this file and rename it: `docs/field-notes/your-topic.md`
+2. Replace the placeholder content with your own lessons
+3. Add a row to the table in [docs/field-notes/README.md](README.md)
+4. Open a pull request — or [submit via issue](https://github.com/paulo-amaral/awesome-digital-public-infrastructure/issues/new?template=share-lesson-learned.yml) if you prefer not to edit files directly
+
+← [Back to Field Notes index](README.md)


### PR DESCRIPTION
## Summary
Makes it easy for practitioners to contribute field notes without needing to edit files directly.

### What's added
- **`.github/ISSUE_TEMPLATE/share-lesson-learned.yml`** — GitHub issue form with fields: context, topic (dropdown matching existing field-note categories), lesson text, optional reference, quality checklist
- **`docs/field-notes/TEMPLATE.md`** — copy-paste starting point for contributors opening a PR with a full new field note page
- **`docs/field-notes/README.md`** — added "Want to contribute?" CTA with links to both paths
- **`CONTRIBUTING.md`** — new "Field Notes (Lessons Learned)" section documenting both contribution paths and quality criteria
- **`add-resource.yml`** — removed stale "Jobs & Opportunities" category, added "Field Notes"

## Type of change
- [x] New feature (contribution infrastructure)