### PR TITLE
feat: add UNDP AILA, DRA, Compass, UNESCO DCF, Deloitte Gov Trends

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -204,6 +204,10 @@ Want to contribute a country profile? See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [DIAL Digital Investment Framework](https://dial.global/) — helps prioritize DPG investments
 - [WEF Global Technology Governance Report](https://www.weforum.org/reports/global-technology-governance-report-2021/) — framework for responsible DPI deployment
 - [GovStack Digital Readiness Assessment](https://www.govstack.global/) — country readiness tool for building-block-based DPI
+- [UNDP AILA — AI Landscape Assessment](https://www.undp.org/digital/aila) — national AI readiness framework assessing government, private sector, civil society, and academia; deployed in 15+ countries since 2024
+- [UNDP DRA — Digital Readiness Assessment](https://www.undp.org/digital/dra) — cross-cutting hybrid assessment covering five digital transformation pillars; deployed in 50+ countries
+- [UNDP Digital Development Compass](https://digitaldevelopmentcompass.undp.org/) — aggregates digital indicators from 140+ open datasets including DPI sub-dimensions: identity, payments, data exchange
+- [UNESCO Digital Competency Framework](https://www.unesco.org/en/digital-competency-framework) — strengthens digital skills and institutional capacity in government for civil servants and policymakers
 
 ### 🔌 Interoperability
 
@@ -279,6 +283,7 @@ Want to contribute a country profile? See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [OECD Going Digital Policy Notes](https://www.oecd.org/going-digital/policy-notes.htm) — country-specific digital transformation guidance
 - [AfDB Digital Transformation Strategy](https://www.afdb.org/en/topics-and-sectors/topics/digital-transformation) — Africa's digital infrastructure priorities
 - [G20 DPI Framework](https://www.g20.org/) — G20 DPI commitments and principles
+- [Deloitte Government Trends 2025](https://www.deloitte.com/us/en/insights/industry/government-public-sector-services/government-trends.html) — annual analysis of how governments are transforming digital service delivery, AI integration, and public infrastructure
 
 ### 👩‍💻 Digital Workforce & Inclusion
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -837,6 +837,46 @@
         <div class="link-title">BMZ Digital.Global</div>
         <div class="link-desc">German Federal Ministry digital development programme — umbrella for GovStack, FAIR Forward (AI), atingi (digital skills), and Digital Transformation Centers worldwide.</div>
       </a>
+      <a class="link-item" href="https://www.undp.org/digital/aila" target="_blank" rel="noopener">
+        <div class="link-meta">
+          <span class="link-org">UNDP</span>
+          <span class="link-tag">Assessment</span>
+        </div>
+        <div class="link-title">AILA — AI Landscape Assessment</div>
+        <div class="link-desc">UNDP's national AI readiness framework — assesses government, private sector, civil society and academia; deployed in 15+ countries since 2024.</div>
+      </a>
+      <a class="link-item" href="https://www.undp.org/digital/dra" target="_blank" rel="noopener">
+        <div class="link-meta">
+          <span class="link-org">UNDP</span>
+          <span class="link-tag">Assessment</span>
+        </div>
+        <div class="link-title">DRA — Digital Readiness Assessment</div>
+        <div class="link-desc">UNDP's cross-cutting digital readiness tool covering five pillars (people, connectivity, government, regulation, economy); deployed in 50+ countries.</div>
+      </a>
+      <a class="link-item" href="https://digitaldevelopmentcompass.undp.org/" target="_blank" rel="noopener">
+        <div class="link-meta">
+          <span class="link-org">UNDP</span>
+          <span class="link-tag">Data</span>
+        </div>
+        <div class="link-title">Digital Development Compass</div>
+        <div class="link-desc">Aggregates digital development indicators from 140+ open datasets worldwide, including DPI sub-dimensions: identity, payments, and data exchange.</div>
+      </a>
+      <a class="link-item" href="https://www.unesco.org/en/digital-competency-framework" target="_blank" rel="noopener">
+        <div class="link-meta">
+          <span class="link-org">UNESCO</span>
+          <span class="link-tag">Capacity</span>
+        </div>
+        <div class="link-title">Digital Competency Framework</div>
+        <div class="link-desc">UNESCO framework for strengthening digital skills and institutional capacity in government — supports civil servants and policymakers in leading digital transformation.</div>
+      </a>
+      <a class="link-item" href="https://www.deloitte.com/us/en/insights/industry/government-public-sector-services/government-trends.html" target="_blank" rel="noopener">
+        <div class="link-meta">
+          <span class="link-org">Deloitte</span>
+          <span class="link-tag">Trends</span>
+        </div>
+        <div class="link-title">Government Trends 2025</div>
+        <div class="link-desc">Annual analysis of how governments are transforming digital service delivery, AI integration, and public infrastructure — useful benchmark for DPI practitioners.</div>
+      </a>
     </div>
     <a class="see-more" href="https://github.com/paulo-amaral/awesome-digital-public-infrastructure#-frameworks--standards">
       All frameworks on GitHub <i class="fa-solid fa-arrow-right"></i>


### PR DESCRIPTION
## Summary
Added 5 digital transformation frameworks to both README.MD and docs/index.html:

| Resource | Org | Where |
|---|---|---|
| [AILA — AI Landscape Assessment](https://www.undp.org/digital/aila) | UNDP | Toolkits + Webpage |
| [DRA — Digital Readiness Assessment](https://www.undp.org/digital/dra) | UNDP | Toolkits + Webpage |
| [Digital Development Compass](https://digitaldevelopmentcompass.undp.org/) | UNDP | Toolkits + Webpage |
| [Digital Competency Framework](https://www.unesco.org/en/digital-competency-framework) | UNESCO | Toolkits + Webpage |
| [Government Trends 2025](https://www.deloitte.com/us/en/insights/industry/government-public-sector-services/government-trends.html) | Deloitte | Research → Policy + Webpage |

## Type of change
- [x] New resource added