### PR TITLE
fix: country profile cards now open rendered markdown

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -719,7 +719,7 @@
   <section class="section">
     <h2><i class="fa-solid fa-earth-asia"></i> Country DPI Profiles</h2>
     <div class="country-grid">
-      <a class="country-card" href="country-profiles/india.md">
+      <a class="country-card" href="https://github.com/paulo-amaral/awesome-digital-public-infrastructure/blob/main/docs/country-profiles/india.md" target="_blank" rel="noopener">
         <span class="flag">🇮🇳</span>
         <h3>India</h3>
         <p>The world's most comprehensive DPI stack at 1.4B scale.</p>
@@ -730,7 +730,7 @@
           <span class="chip">ABDM</span>
         </div>
       </a>
-      <a class="country-card" href="country-profiles/estonia.md">
+      <a class="country-card" href="https://github.com/paulo-amaral/awesome-digital-public-infrastructure/blob/main/docs/country-profiles/estonia.md" target="_blank" rel="noopener">
         <span class="flag">🇪🇪</span>
         <h3>Estonia</h3>
         <p>World's most advanced digital society — X-Road, e-Residency, i-Voting.</p>
@@ -740,7 +740,7 @@
           <span class="chip">KSI</span>
         </div>
       </a>
-      <a class="country-card" href="country-profiles/brazil.md">
+      <a class="country-card" href="https://github.com/paulo-amaral/awesome-digital-public-infrastructure/blob/main/docs/country-profiles/brazil.md" target="_blank" rel="noopener">
         <span class="flag">🇧🇷</span>
         <h3>Brazil</h3>
         <p>PIX reached 100M users faster than any payment system in history.</p>


### PR DESCRIPTION
## Summary
Country cards (India, Estonia, Brazil) were linking to relative `.md` paths which GitHub Pages serves as raw text. Changed to full `github.com/blob/main/…` URLs so GitHub renders the markdown properly.

**Before:** `href="country-profiles/india.md"` → raw text  
**After:** `href="https://github.com/paulo-amaral/…/blob/main/docs/country-profiles/india.md"` → rendered markdown

Also added `target="_blank" rel="noopener"` so profiles open in a new tab.

## Type of change
- [x] Bug fix